### PR TITLE
feat: include brew sm-plugin during installation

### DIFF
--- a/Formula/tedge.rb
+++ b/Formula/tedge.rb
@@ -18,6 +18,11 @@ class Tedge < Formula
         end
     end
 
+    resource "sm-plugin-brew" do
+        url "https://raw.githubusercontent.com/thin-edge/homebrew-tedge/main/extras/sm-plugins/brew"
+        sha256 "f29f7cffb93be0adb8b8376bc74e249c70703799ea048a653a2f29af33dc5204"
+    end
+
     def user
         Utils.safe_popen_read("id", "-un").chomp
     end
@@ -52,6 +57,18 @@ class Tedge < Formula
         end
 
         system "tedge", "init", "--config-dir", "#{config_dir}", "--user=#{user}", "--group=#{group}"
+
+        # Install sm-plugins in a shared folder
+        share_sm_plugins = (pkgshare/"sm-plugins")
+        share_sm_plugins.mkpath
+        resource("sm-plugin-brew").stage { share_sm_plugins.install "brew" }
+
+        # Symlink to the brew sm-plugin from the shared folder
+        # This allows users to remove the symlink if they don't want the sm-plugin
+        # rather than deleting the whole file
+        sm_plugins_dir = (etc/"tedge/sm-plugins")
+        sm_plugins_dir.install_symlink share_sm_plugins/"brew"
+        system "chmod", "555", "#{share_sm_plugins}/brew"
     end
 
     def caveats


### PR DESCRIPTION
Include the `brew` sm-plugin during installation to allow users to list the brew packages that they have on their system.

The brew sm-plugin is symlinked to the tedge/sm-plugins folder (as shown below):

```sh
ls -l $(brew --prefix)/etc/tedge/sm-plugins/*
lrwxr-xr-x  1 example  admin  70 May  9 09:31 /opt/homebrew/etc/tedge/sm-plugins/brew -> ../../../Cellar/tedge/1.0.2-rc273+gd05e9b6/share/tedge/sm-plugins/brew
```