### PR TITLE
fix: tedge config dir instructions

### DIFF
--- a/Formula/tedge.rb
+++ b/Formula/tedge.rb
@@ -159,8 +159,8 @@ class Tedge < Formula
                 sh -c 'echo include_dir #{etc}/tedge/mosquitto-conf >> "#{etc}/mosquitto/mosquitto.conf"'
 
             Configure your zsh profile then reload it
-                sh -c 'export TEDGE_CONFIG_DIR="#{etc}/tedge"' >> $HOME/.zshrc
-                . $HOME/.zshrc
+                sh -c 'echo export TEDGE_CONFIG_DIR=\"#{etc}/tedge\"' >> "$HOME/.zshrc"
+                . "$HOME/.zshrc"
 
             Onboarding instructions:
 

--- a/scripts/tedge.rb.template
+++ b/scripts/tedge.rb.template
@@ -158,8 +158,8 @@ class Tedge < Formula
                 sh -c 'echo include_dir #{etc}/tedge/mosquitto-conf >> "#{etc}/mosquitto/mosquitto.conf"'
 
             Configure your zsh profile then reload it
-                sh -c 'export TEDGE_CONFIG_DIR="#{etc}/tedge"' >> $HOME/.zshrc
-                . $HOME/.zshrc
+                sh -c 'echo export TEDGE_CONFIG_DIR=\"#{etc}/tedge\"' >> "$HOME/.zshrc"
+                . "$HOME/.zshrc"
 
             Onboarding instructions:
 


### PR DESCRIPTION
Fix the instructions which direct the user to add the `export TEDGE_CONFIG_DIR=...` one-liner to their .zshrc file