### PR TITLE
feat: update tedge-p11-server service definition

### DIFF
--- a/Formula/tedge-p11-server-main.rb
+++ b/Formula/tedge-p11-server-main.rb
@@ -32,27 +32,15 @@ class TedgeP11ServerMain < Formula
         run_dir.mkpath
     end
 
-    def post_install
-        # TODO: Change once this changes to a toml file
-        config_file = (etc/"tedge/plugins/tedge-p11-server.toml")
-        if !config_file.exist?
-            config_file.write <<~EOS
-                [device.cryptoki]
-                module_path = "#{HOMEBREW_PREFIX}/lib/libykcs11.dylib"
-                pin = "123456"
-            EOS
-        end
-    end
-
     service do
         name macos: "tedge-p11-server-main",
              linux: "tedge-p11-server-main"
-        run ["#{HOMEBREW_PREFIX}/bin/tedge-p11-server"]
+        run ["#{HOMEBREW_PREFIX}/bin/tedge-p11-server", "--socket-path", "#{HOMEBREW_PREFIX}/var/tedge-p11-server/tedge-p11-server.sock"]
         environment_variables TEDGE_CONFIG_DIR: etc/"tedge"
         log_path var/"log/tedge-p11-server.log"
         keep_alive true
         restart_delay 5
-      end
+    end
 
     def caveats
         <<~EOS

--- a/scripts/tedge-p11-server-main.template.rb
+++ b/scripts/tedge-p11-server-main.template.rb
@@ -31,27 +31,15 @@ class TedgeP11ServerMain < Formula
         run_dir.mkpath
     end
 
-    def post_install
-        # TODO: Change once this changes to a toml file
-        config_file = (etc/"tedge/plugins/tedge-p11-server.toml")
-        if !config_file.exist?
-            config_file.write <<~EOS
-                [device.cryptoki]
-                module_path = "#{HOMEBREW_PREFIX}/lib/libykcs11.dylib"
-                pin = "123456"
-            EOS
-        end
-    end
-
     service do
         name macos: "tedge-p11-server-main",
              linux: "tedge-p11-server-main"
-        run ["#{HOMEBREW_PREFIX}/bin/tedge-p11-server"]
+        run ["#{HOMEBREW_PREFIX}/bin/tedge-p11-server", "--socket-path", "#{HOMEBREW_PREFIX}/var/tedge-p11-server/tedge-p11-server.sock"]
         environment_variables TEDGE_CONFIG_DIR: etc/"tedge"
         log_path var/"log/tedge-p11-server.log"
         keep_alive true
         restart_delay 5
-      end
+    end
 
     def caveats
         <<~EOS


### PR DESCRIPTION
Update the tedge-p11-service as it now can read configuration files from the tedge.toml file.